### PR TITLE
Braille rendering

### DIFF
--- a/src/Graphics/Text/PCF.hs
+++ b/src/Graphics/Text/PCF.hs
@@ -355,12 +355,14 @@ renderBraillePCF font = unlines . concatMap (foldMap (layoutLine . pcf_text_glyp
                                   , brailleFrom8Bit <$> B.unpack glLine
                                   ) of
                            ([oh], bh:gl')
-                            | newHangsOver==0  -> toEnum (fromEnum oh.|.fromEnum bh)
+                            | newHangsOver==0 || null gl'
+                                               -> toEnum (fromEnum oh.|.fromEnum bh)
                                                   : gl' ++ contin
                             | otherwise        -> toEnum (fromEnum oh.|.fromEnum bh)
                                                   : init gl' ++ contin
                            ([], bh:gl')
-                            | newHangsOver==0  -> bh : gl' ++ contin
+                            | newHangsOver==0 || null gl'
+                                               -> bh : gl' ++ contin
                             | otherwise        -> bh : init gl' ++ contin )
                    overhang glyphRendrd
                    $ go height

--- a/src/Graphics/Text/PCF.hs
+++ b/src/Graphics/Text/PCF.hs
@@ -50,6 +50,10 @@ module Graphics.Text.PCF (
         pcf_text_ascii,
         glyph_ascii,
         glyph_ascii_lines,
+        -- * Braille Rendering
+        pcf_text_braille,
+        glyph_braille,
+        glyph_braille_lines,
         -- * Metadata
         getPCFProps,
         -- * Types

--- a/src/Graphics/Text/PCF.hs
+++ b/src/Graphics/Text/PCF.hs
@@ -341,22 +341,22 @@ renderBraillePCF font = unlines . concatMap (foldMap (layoutLine . pcf_text_glyp
                                 . lines
  where layoutLine :: [PCFGlyph] -> [String]
        layoutLine line = go 0 h (repeat []) line
-        where h = maximum $ glyph_height <$> line
+        where h = maximum $ glyph_ascend <$> line
        go :: Int -> Int -> [String] -> [PCFGlyph] -> [String]
        go _ _ overhang [] = (\oh -> if null (drop 1 oh) then [] else take 1 oh) <$> overhang
-       go lPad height overhang (c:cs)
+       go lPad ascend overhang (c:cs)
          = let lPad' = case overhang of
                  ((_:_:_):_) -> lPad+1
                  _           -> lPad
                (glyphRendrd, newHangsOver)
-                   = glyph_braille_lines_bs' lPad' (height - glyph_height c) c
+                   = glyph_braille_lines_bs' lPad' (ascend - glyph_ascend c) c
                glyphsTouch = or [ zeroBits /= if null prev
                                     then bshiftL oh .&. bh
                                     else oh .&. bshiftL bh
                                 | (ohc:prev, bhs) <- zip overhang glyphRendrd
                                 , let [oh,bh] = [brailleTo8Bit ohc, B.head bhs] ]
            in if glyphsTouch
-               then go (lPad+1) height overhang (c:cs)
+               then go (lPad+1) ascend overhang (c:cs)
                else zipWith3 (\hang glLine contin
                           -> case ( hang
                                   , brailleFrom8Bit <$> B.unpack glLine
@@ -372,7 +372,7 @@ renderBraillePCF font = unlines . concatMap (foldMap (layoutLine . pcf_text_glyp
                                                -> bh : gl' ++ contin
                             | otherwise        -> bh : init gl' ++ contin )
                    overhang glyphRendrd
-                   $ go 0 height
+                   $ go 0 ascend
                         ( if newHangsOver>0
                            then map brailleFrom8Bit . B.unpack . last2 <$> glyphRendrd
                            else pure . brailleFrom8Bit . B.last <$> glyphRendrd
@@ -380,6 +380,8 @@ renderBraillePCF font = unlines . concatMap (foldMap (layoutLine . pcf_text_glyp
        
        bshiftL :: Word8 -> Word8
        bshiftL bc = (bc.&.0x38)`shiftR`3 .|. (bc.&.0x80)`shiftR`1
+       glyph_ascend :: PCFGlyph -> Int
+       glyph_ascend gl = fromIntegral (metrics_character_ascent $ glyph_metrics gl)
 
 
 last2 :: ByteString -> ByteString

--- a/src/Graphics/Text/PCF/Types.hs
+++ b/src/Graphics/Text/PCF/Types.hs
@@ -14,9 +14,11 @@ module Graphics.Text.PCF.Types (
         glyph_ascii_lines,
         glyph_braille,
         glyph_braille_lines,
+        glyph_braille_lines_bs',
         pcf_text_string,
         pcf_text_ascii,
-        pcf_text_braille
+        pcf_text_braille,
+        brailleFrom8Bit
     ) where
 
 import Data.Binary

--- a/src/Graphics/Text/PCF/Types.hs
+++ b/src/Graphics/Text/PCF/Types.hs
@@ -202,7 +202,7 @@ glyph_braille_lines_bs' lPadding tPadding PCFGlyph{..}
 
         paddedWidth = fromIntegral glyph_width + lPadding
         showBits rws = first B.fromStrict
-                         $ B.unfoldrN (paddedWidth`quot`2+1) build 0
+                         $ B.unfoldrN ((paddedWidth+1)`quot`2) build 0
          where build x = Just ( assemble $ [ index r (7-2*k-o)
                                            | o <- [0,1]
                                            , r <- take 3 rws ]

--- a/src/Graphics/Text/PCF/Types.hs
+++ b/src/Graphics/Text/PCF/Types.hs
@@ -185,11 +185,11 @@ glyph_braille_lines_bs PCFGlyph{..} = map showBits rs
 
         showBits rws = B.fromStrict . fst
                          $ B.unfoldrN (fromIntegral glyph_width`quot`2) build 0
-         where build x = Just ( assemble $ [ B.index r i `testBit` fromIntegral (8-2*k-o)
+         where build x = Just ( assemble $ [ B.index r i `testBit` fromIntegral (7-2*k-o)
                                            | o <- [0,1]
                                            , r <- take 3 rws ]
                                         ++ [ B.index (last rws) i
-                                                         `testBit` fromIntegral (8-2*k-o)
+                                                         `testBit` fromIntegral (7-2*k-o)
                                            | o <- [0,1] ]
                               , x+1 )
                 where (i,k) = x`divMod`4

--- a/src/Graphics/Text/PCF/Types.hs
+++ b/src/Graphics/Text/PCF/Types.hs
@@ -29,7 +29,7 @@ import Data.Vector (Vector)
 import Data.IntMap (IntMap)
 import Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString as B (unfoldrN)
-import qualified Data.ByteString.Lazy as B (concatMap, take, map, index, fromStrict)
+import qualified Data.ByteString.Lazy as B (concatMap, take, map, index, fromStrict, length)
 import qualified Data.ByteString.Lazy.Char8 as B (unpack, splitAt, intercalate, concat)
 import qualified Data.Vector.Storable as VS
 
@@ -184,15 +184,18 @@ glyph_braille_lines_bs PCFGlyph{..} = map showBits rs
                           -> (r:rg) : rgs
 
         showBits rws = B.fromStrict . fst
-                         $ B.unfoldrN (fromIntegral glyph_width`quot`2) build 0
-         where build x = Just ( assemble $ [ B.index r i `testBit` fromIntegral (7-2*k-o)
+                         $ B.unfoldrN (fromIntegral glyph_width`quot`2+1) build 0
+         where build x = Just ( assemble $ [ index r i `testBit` fromIntegral (7-2*k-o)
                                            | o <- [0,1]
                                            , r <- take 3 rws ]
-                                        ++ [ B.index (last rws) i
+                                        ++ [ index (last rws) i
                                                          `testBit` fromIntegral (7-2*k-o)
                                            | o <- [0,1] ]
                               , x+1 )
                 where (i,k) = x`divMod`4
+                      index r i
+                       | i < B.length r  = B.index r i
+                       | otherwise       = zeroBits
                       assemble pixels = foldl' (.|.) zeroBits
                                           [ bit i | (i,px) <- zip [0..] pixels
                                                   , px ]

--- a/src/Graphics/Text/PCF/Types.hs
+++ b/src/Graphics/Text/PCF/Types.hs
@@ -23,6 +23,7 @@ import Data.Binary
 import Data.Bits
 import Data.Int
 import Data.Monoid
+import Data.Ord (comparing)
 import Data.List
 import Data.Vector (Vector)
 import Data.IntMap (IntMap)
@@ -213,8 +214,15 @@ pcf_text_string = map glyph_char . pcf_text_glyphs
 
 -- | ASCII rendering of a whole PCFText string rendering.
 pcf_text_ascii :: PCFText -> String
-pcf_text_ascii = B.unpack . B.intercalate "\n" . map B.concat . transpose . map glyph_ascii_lines_bs . pcf_text_glyphs
+pcf_text_ascii = unlines . map concat . transpose
+            . alignBottom . map (map B.unpack) . map glyph_ascii_lines_bs . pcf_text_glyphs
 
 -- | Braille display of a whole PCFText string rendering.
 pcf_text_braille :: PCFText -> String
-pcf_text_braille = unlines . map concat . transpose . map glyph_braille_lines . pcf_text_glyphs
+pcf_text_braille = unlines . map concat . transpose
+                     . alignBottom . map glyph_braille_lines . pcf_text_glyphs
+
+alignBottom :: [[String]] -> [[String]]
+alignBottom l = map (\c -> replicate (hmax - length c) (map (const ' ') $ head c) ++ c) l
+ where cmax = maximumBy (comparing length) l
+       hmax = length cmax

--- a/src/Graphics/Text/PCF/Types.hs
+++ b/src/Graphics/Text/PCF/Types.hs
@@ -18,7 +18,8 @@ module Graphics.Text.PCF.Types (
         pcf_text_string,
         pcf_text_ascii,
         pcf_text_braille,
-        brailleFrom8Bit
+        brailleFrom8Bit,
+        brailleTo8Bit
     ) where
 
 import Data.Binary
@@ -166,6 +167,9 @@ glyph_braille_lines = map (map brailleFrom8Bit . B.unpack)
 
 brailleFrom8Bit :: Enum i => i -> Char
 brailleFrom8Bit = toEnum . (.|.0x2800) . fromEnum
+
+brailleTo8Bit :: Enum i => Char -> i
+brailleTo8Bit = toEnum . (.&.0xFF) . fromEnum
 
 glyph_ascii_lines_bs :: PCFGlyph -> [ByteString]
 glyph_ascii_lines_bs PCFGlyph{..} = map (B.take (fromIntegral glyph_width) . showBits) rs

--- a/src/Graphics/Text/PCF/Types.hs
+++ b/src/Graphics/Text/PCF/Types.hs
@@ -159,8 +159,11 @@ glyph_ascii_lines = map B.unpack . glyph_ascii_lines_bs
 -- | Render glyph bitmap as a list of strings representing lines a Braille 2×4 grid of
 --   pixel represents the raster.
 glyph_braille_lines :: PCFGlyph -> [String]
-glyph_braille_lines = map (map (toEnum . (+0x2800) . fromEnum) . B.unpack)
+glyph_braille_lines = map (map brailleFrom8Bit . B.unpack)
                        . fst . glyph_braille_lines_bs' 0 0
+
+brailleFrom8Bit :: Enum i => i -> Char
+brailleFrom8Bit = toEnum . (.|.0x2800) . fromEnum
 
 glyph_ascii_lines_bs :: PCFGlyph -> [ByteString]
 glyph_ascii_lines_bs PCFGlyph{..} = map (B.take (fromIntegral glyph_width) . showBits) rs


### PR DESCRIPTION
This is inspired by [the drawille library](https://github.com/asciimoo/drawille) (also [available in Haskell](http://hackage.haskell.org/package/drawille)), which rasterizes graphics as Unicode plaintext, namely the Braille character set. I was intrigued by the possibility to use this to include fat headings in plaintext files. PCF fonts are aimed at such simple binary output, so seemed a good fit.

My implementation isn't great &ndash; in many places reinvents the wheel, simply ignores the bearings information. It does give somewhat ok kerning, though that's hackish too.

Some examples, using [this script](https://gist.github.com/leftaroundabout/f09cecbdb39c39fc19fc8f560ad8939d):
```
$ braillster <<< "Hello, World!"
⣿⠀⠀⢸⡇⠀⣀⣀⠀⢸⡇⣿⠀⢀⣀⣀⠀⠀⠀⢻⡄⢀⣿⡇⠀⣼⠇⢀⣀⣀⠀⢀⡀⣀⢸⡇⠀⣀⡀⣿⢸⡇
⣿⠶⠶⢾⡇⣾⣭⣭⣷⢸⡇⣿⢰⡟⠉⠙⣷⠀⠀⠘⣧⣸⡇⣿⢠⡟⢰⡟⠉⠙⣷⢸⡟⠉⢸⡇⣾⠋⠉⣿⢸⡇
⣿⠀⠀⢸⡇⠻⣦⣤⡴⢸⡇⣿⠘⢷⣤⣴⠟⣤⡄⠀⢻⣿⠀⢸⣿⠁⠘⢷⣤⣴⠟⢸⡇⠀⢸⡇⠻⣦⡴⣿⢨⡅
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
$ braillster -b <<< "Hello, World!"
⣿⡇⠀⠀⣿⡇⠀⣀⣀⡀⠀⣿⡇⣿⡇⠀⢀⣀⡀⠀⠀⠀⠀⢻⣷⠀⣸⣿⡀⢠⡟⠀⢀⣀⡀⠀⢀⣀⢀⡀⣿⡇⠀⣀⣀⢸⣿⢸⣿
⣿⡷⠶⠶⣿⡇⣾⣯⣭⣿⡆⣿⡇⣿⡇⣾⡟⠉⢻⣷⠀⠀⠀⠘⣿⣆⡿⢿⣇⣾⠃⣾⡟⠉⢻⣷⢸⣿⠛⠃⣿⡇⣾⡟⠉⢹⣿⠈⣿
⣿⡇⠀⠀⣿⡇⠻⢷⣤⣤⡆⣿⡇⣿⡇⠻⢷⣤⡾⠟⢰⣶⠀⠀⢻⣿⠇⠸⣿⡟⠀⠻⢷⣤⡾⠟⢸⣿⠀⠀⣿⡇⠻⣷⣤⢾⣿⢠⣤
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠠⠟⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
$ braillster -i <<< "Hello, World!"
⠀⣿⠀⠀⢀⡟⠀⠀⣀⡀⠀⢸⠇⢸⠇⠀⢀⣀⡀⠀⠀⣿⠀⢠⣿⡇⢀⡾⠁⠀⢀⣀⡀⠀⣀⠀⣀⠀⡿⠀⠀⣀⣀⡟⠀⡟
⢰⡷⠶⠶⢾⠇⣰⣏⣩⠏⠀⣿⠀⣿⢀⡾⠋⠉⣿⠀⠀⣿⢀⡞⢸⣇⡾⠁⢀⡾⠋⠉⣿⢰⣷⠟⠉⢸⡇⢠⠞⠉⣽⠇⢸⠇
⣼⠁⠀⠀⣿⠀⢿⣤⣤⠖⢰⡇⢰⡇⠸⣧⣤⠾⠃⢠⡄⢹⡞⠀⢸⡿⠁⠀⠸⣧⣤⠾⠃⣼⠁⠀⠀⣾⠀⢿⣤⢾⡿⠀⣬⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
$ braillster -bi <<< "Hello, World!"
⠀⣿⡏⠀⢠⣿⠇⠀⢀⣀⡀⠀⢰⣿⠃⢰⣿⠃⠀⢀⣀⣀⠀⠀⠀⣿⡇⢀⣾⣿⠀⣼⠏⠀⠀⣀⣀⡀⠀⣀⡀⢀⡀⢰⣿⠃⠀⢀⣀⣸⣿⠃⢸⣿⠃
⢸⣿⠷⠶⣾⣿⢀⣾⣏⣽⡿⠀⣾⡿⠀⣾⡿⢀⣾⠟⠉⣿⡇⠀⠀⣿⡇⣼⢻⣿⣼⠏⠀⣰⡿⠋⢹⣿⢸⣿⡵⠛⠀⣾⡿⠀⣴⡟⢉⣿⡿⠀⣸⡟⠀
⣾⡟⠀⢀⣿⡇⠸⢿⣭⣥⠴⢠⣿⠇⢠⣿⠇⠸⢿⣦⡴⠟⢁⣶⡆⢿⣿⠃⢸⣿⠏⠀⠀⠿⣷⣤⠾⠋⣾⡟⠀⠀⢠⣿⠇⠸⣿⡴⢫⣿⠇⢠⣤⡄⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠠⠞⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
```
This looks much better in my terminal than it does on Github, like
![braille-examples](https://user-images.githubusercontent.com/1528675/34417301-0c0af03a-ebf8-11e7-97c7-ea0008656776.png)
