### PR TITLE
Fix compilation issues. (Could not deduce MonadFail)

### DIFF
--- a/pcf-font.cabal
+++ b/pcf-font.cabal
@@ -1,5 +1,5 @@
 name:                pcf-font
-version:             0.2.2.0
+version:             0.2.2.1
 synopsis:            PCF font parsing and rendering library.
 description:         pcf-font is a library for parsing and rendering X11 PCF fonts.
 homepage:            https://github.com/michael-swan/pcf-font

--- a/src/Graphics/Text/PCF.hs
+++ b/src/Graphics/Text/PCF.hs
@@ -79,7 +79,7 @@ import qualified Data.IntMap as IntMap
 import Graphics.Text.PCF.Types
 import Codec.Compression.GZip
 
-assert :: Monad m => Bool -> String -> m ()
+assert :: MonadFail m => Bool -> String -> m ()
 assert True  = const $ return ()
 assert False = fail
 


### PR DESCRIPTION
I fixed this compilation error on ghc 8.10 by applying the recommended fix from GHC.
```
src/Graphics/Text/PCF.hs:84:16: error:
    • Could not deduce (MonadFail m) arising from a use of ‘fail’
      from the context: Monad m
        bound by the type signature for:
                   assert :: forall (m :: * -> *). Monad m => Bool -> String -> m ()
        at src/Graphics/Text/PCF.hs:82:1-43
      Possible fix:
        add (MonadFail m) to the context of
          the type signature for:
            assert :: forall (m :: * -> *). Monad m => Bool -> String -> m ()
    • In the expression: fail
      In an equation for ‘assert’: assert False = fail
   |
84 | assert False = fail
   |                ^^^^
```