### PR TITLE
Future-proof against addition of Data.List.!?

### DIFF
--- a/src/Graphics/Text/PCF.hs
+++ b/src/Graphics/Text/PCF.hs
@@ -69,7 +69,6 @@ import qualified Data.Map.Strict as M
 import Control.Monad
 import Control.Applicative
 import Data.ByteString.Lazy (ByteString)
-import Data.Vector ((!?))
 import GHC.Exts
 import Data.Char
 import qualified Data.ByteString.Lazy as B
@@ -103,8 +102,8 @@ getPCFProps PCF{..} = flip map properties_props $ \Prop{..} ->
 getPCFGlyph :: PCF -> Char -> Maybe PCFGlyph
 getPCFGlyph PCF{..} c = do
         glyph_index <- fromIntegral <$> IntMap.lookup (ord c) encodings_glyph_indices
-        offset      <- fromIntegral <$> (bitmaps_offsets !? glyph_index)
-        m@Metrics{..} <- metrics_metrics !? glyph_index
+        offset      <- fromIntegral <$> (bitmaps_offsets V.!? glyph_index)
+        m@Metrics{..} <- metrics_metrics V.!? glyph_index
         let cols = fromIntegral $ metrics_right_sided_bearings - metrics_left_sided_bearings
             rows = fromIntegral $ metrics_character_ascent + metrics_character_descent
         pitch <- case tableMetaGlyphPad meta_bitmaps of


### PR DESCRIPTION
`base-4.19` (and GHC 9.8) will export `Data.List.!?`, which will cause a name clash with `Data.Vector.!?` in 
https://github.com/michael-swan/pcf-font/blob/7d4ea6db59b1bea6747effa1df63a52c278a6d6a/src/Graphics/Text/PCF.hs#L104-L106

This PR qualifies `!?` to make it unambiguous. 

See https://github.com/haskell/core-libraries-committee/issues/110#issuecomment-1359037078 for CLC discussion of the change.